### PR TITLE
feat(core): AndroidOptions/ApnsOptions + hooks at Message/Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.1] - 2025-09-22
+### Added
+- Support for custom notification channels in **Firebase Cloud Messaging**.
+- New example in `examples/send_fcm_channels.php`.
+- `AndroidOptions` and `ApnsOptions` to configure platform-specific options.
+- `platformOverrides` in `PushMessage` to set platform-specific options.
+
+---
+
 ## [Unreleased]
 - Support for additional providers (Twilio Notify, OneSignal, APNs).
 - Adapters for Laravel and Symfony.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Driver-agnostic notifications core for PHP (starting with Firebase Cloud Messaging HTTP v1).  
 Built in Mexico by **DEV1 Softworks Labs**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Version: 1.0](https://img.shields.io/badge/version-0.1.0-green.svg)](#)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Version: 1.1](https://img.shields.io/badge/version-1.1-green.svg)](#)
 
 ---
 
@@ -24,7 +24,7 @@ Require the library (PHP 7.4+):
 composer require dev1/notify-core
 ```
 
-For development / examples you’ll need a PSR-18 client + PSR-17 factories.  
+For development and examples, you’ll need a PSR-18 client and PSR-17 factories.  
 We recommend:
 
 ```bash
@@ -95,29 +95,31 @@ var_dump($result);
 ## Requirements
 - PHP ^7.4
 - ext-openssl
-- A Firebase Project with a Service Account JSON, Legacy FCM is not compatible.
+- A Firebase Project with a Service Account JSON (Legacy FCM is not compatible)
 
 ---
 
-## Next steps
-- [ ] Increase drivers availability (Twilio Notify, OneSignal, APNs)
+## Roadmap
+- [ ] Add more drivers (Twilio Notify, OneSignal, APNs)
 - [x] Laravel adapter (`dev1/laravel-notify`)
 - [ ] Symfony bundle (`dev1/symfony-notify-bundle`)
 - [ ] Unit tests & CI
-- [ ] Advanced platform overrides (Android/APNs/WebPush)
+- [x] Advanced platform overrides (Android/APNs)
 
 ---
 
 ## License
 MIT License © DEV1 Softworks Labs
 
-## Want to collaborate?
+---
 
-We welcome contributions from the community! If you'd like to help improve this project, please:
+## Contributing
 
-- Fork the repository and create a new branch for your changes.
-- Follow the existing code style and add tests where appropriate.
-- Open a pull request describing your changes and the motivation behind them.
-- Check the issues tab for open tasks or suggest new features.
+We welcome contributions from the community! To get started:
 
-If you have questions or need guidance, feel free to open an issue or start a discussion. Thank you for considering contributing to DEV1 Notify Core!
+1. Fork the repository and create a new branch for your changes.
+2. Follow the existing code style and add tests where appropriate.
+3. Open a pull request describing your changes and the motivation behind them.
+4. Check the issues tab for open tasks or suggest new features.
+
+If you have questions or need guidance, please open an issue or start a discussion. Thank you for considering contributing to DEV1 Notify Core!

--- a/examples/send_fcm_channels.php
+++ b/examples/send_fcm_channels.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use Dev1\NotifyCore\Auth\GoogleServiceAccountTokenProvider;
+use Dev1\NotifyCore\DTO\PushMessage;
+use Dev1\NotifyCore\DTO\PushTarget;
+use Dev1\NotifyCore\Factory\FcmClientFactory;
+use Dev1\NotifyCore\Platform\AndroidOptions;
+use Dev1\NotifyCore\Platform\ApnsOptions;
+use Dev1\NotifyCore\Registry\ClientRegistry;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Component\HttpClient\Psr18Client;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// ========= CONFIGURE FOR TESTS ===========
+$projectId =  'YOUR_PROJECT_ID';
+$deviceToken = 'YOUR_DEVICE_TOKEN';
+$serviceAccountPath = __DIR__ . '/service-account.json';
+// ========= CONFIGURE FOR TESTS IN CUSTOM CHANNELS ===========
+$androidChannelId   = 'your_android_custom_channel_id';
+$ttlSeconds         = 3600; // se formatea a "Xs" en el transport
+$apnsPriority       = '10';
+// =========================================
+
+if (!is_file($serviceAccountPath)) {
+    fwrite(STDERR, "Service Account file not found: {$serviceAccountPath}\n");
+    exit(1);
+}
+
+$sa = json_decode(file_get_contents($serviceAccountPath), true);
+
+if (!is_array($sa) || empty($sa['client_email']) || empty($sa['private_key'])) {
+    fwrite(STDERR, "Service Account JSON does not contain valid client_email/private_key.\n");
+    exit(1);
+}
+
+$psr17 = new Psr17Factory();
+$http  = new Psr18Client();
+
+// Token Provider (Google SA → OAuth2)
+$tokenProvider = new GoogleServiceAccountTokenProvider(
+    $http,
+    $psr17,
+    $psr17,
+    null, // LoggerInterface|null
+    [
+        'client_email' => $sa['client_email'],
+        'private_key'  => $sa['private_key'],
+        // 'token_uri' => 'https://oauth2.googleapis.com/token', // optional
+        // 'scope'     => 'https://www.googleapis.com/auth/firebase.messaging', // optional
+    ]
+);
+
+// Creates FCM v1 client with factory
+$fcmClient = FcmClientFactory::create(
+    $http,
+    $psr17,
+    $psr17,
+    $tokenProvider,
+    null, // LoggerInterface|null
+    [
+        'project_id' => $projectId,
+        // 'endpoint' => 'https://fcm.googleapis.com/v1/projects/{project_id}/messages:send', // optional
+        // 'timeout'  => 5, // optional
+    ]
+);
+
+$registry = new ClientRegistry();
+$registry->register('fcm', $fcmClient, true);
+
+// ============ NEW PLATFORM OVERRIDES =============
+// ANDROID
+$android = AndroidOptions::make()
+    ->withChannelId($androidChannelId)
+    ->withPriority('high')
+    ->withTtl($ttlSeconds)
+    ->withNotification([
+        'sound' => 'default',
+        'color' => '#FF0000',
+    ])
+    ->withData([
+        'order_id' => '123',
+        'foo'      => 'bar',
+    ]);
+
+// APNs
+$apns = ApnsOptions::make()
+    ->withHeaders([
+        'apns-priority' => $apnsPriority, // 10 = immediate, 5 = background
+        'apns-push-type' => 'alert', // VoIP = for CallKit apps, 'alert' = regular notifications, 'background' = silent notifications
+        // 'apns-expiration' => '0', // 0 = immediately, or unix timestamp
+        // 'apns-topic' => 'com.your.app.bundle', // your app bundle id
+    ])
+    ->withAps([
+        'sound' => 'default',
+        'mutable-content' => 1,
+        // 'content-available' => 1, // for silent notifications
+    ])
+    ->withCustom([
+        'order_id' => '123',
+        'foo'      => 'bar',
+    ]);
+
+$platformOverrides = [
+    'android' => $android,
+    'apns'    => $apns,
+];
+
+$message = new PushMessage(
+    'Hello from DEV1 Notify with Custom Channels',
+    'If you see this notification, FCM v1 with custom channels is working as a charm. Thanks for trusting in DEV1.',
+    [], // global data
+    $platformOverrides
+);
+
+$target = new PushTarget($deviceToken);
+
+$result = $registry->client()->send($message, $target);
+
+// ============ PRINTS RESULT =============
+echo "Success: "      . ($result->success ? 'true' : 'false') . PHP_EOL;
+echo "ID: "           . ($result->id ?? '(none)') . PHP_EOL;
+echo "ErrorCode: "    . ($result->errorCode ?? '(none)') . PHP_EOL;
+echo "ErrorMessage: " . ($result->errorMessage ?? '(none)') . PHP_EOL;

--- a/src/Builders/MessageBuilder.php
+++ b/src/Builders/MessageBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Dev1\NotifyCore\Builders;
+
+use Dev1\NotifyCore\Message;
+use Dev1\NotifyCore\Platform\AndroidOptions;
+use Dev1\NotifyCore\Platform\ApnsOptions;
+
+final class MessageBuilder
+{
+    private Message $message;
+
+    public function __construct()
+    {
+        $this->message = new Message();
+    }
+
+    public function withAndroid(AndroidOptions $android): self
+    {
+        $this->message = $this->message->withAndroid($android);
+        return $this;
+    }
+
+    public function withApns(ApnsOptions $apns): self
+    {
+        $this->message = $this->message->withApns($apns);
+        return $this;
+    }
+
+    public function withAndroidChannelId(string $channelId): self
+    {
+        $android = $this->message->android() ?: AndroidOptions::make();
+        $android = $android->withChannelId($channelId);
+        return $this->withAndroid($android);
+    }
+
+    public function withApnsPriority(string $priority): self
+    {
+        $apns = $this->message->apns() ?: ApnsOptions::make();
+        $apns = $apns->withAps(['priority' => $priority]);
+        return $this->withApns($apns);
+    }
+
+    public function build(): Message
+    {
+        return $this->message;
+    }
+}

--- a/src/Contracts/PlatformOptions.php
+++ b/src/Contracts/PlatformOptions.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Dev1\NotifyCore\Contracts;
+
+interface PlatformOptions
+{
+    public function toArray(): array;
+}

--- a/src/Message.php
+++ b/src/Message.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Dev1\NotifyCore;
+
+use Dev1\NotifyCore\Platform\AndroidOptions;
+use Dev1\NotifyCore\Platform\ApnsOptions;
+
+final class Message
+{
+    private ?AndroidOptions $androidOptions = null;
+
+    private ?ApnsOptions $apnsOptions = null;
+
+    public function withAndroid(?AndroidOptions $android): self
+    {
+        $clone = clone $this;
+        $clone->androidOptions = $android;
+        return $clone;
+    }
+
+    public function withApns(?ApnsOptions $apns): self
+    {
+        $clone = clone $this;
+        $clone->apnsOptions = $apns;
+        return $clone;
+    }
+
+    public function android(): ?AndroidOptions
+    {
+        return $this->androidOptions;
+    }
+
+    public function apns(): ?ApnsOptions
+    {
+        return $this->apnsOptions;
+    }
+
+    public function toArray(): array
+    {
+        $base = [];
+        if ($this->androidOptions) {
+            $base['android'] = $this->androidOptions->toArray();
+        }
+        if ($this->apnsOptions) {
+            $base['apns'] = $this->apnsOptions->toArray();
+        }
+        return $base;
+    }
+}

--- a/src/Platform/AndroidOptions.php
+++ b/src/Platform/AndroidOptions.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Dev1\NotifyCore\Platform;
+
+use Dev1\NotifyCore\Contracts\PlatformOptions;
+
+final class AndroidOptions implements PlatformOptions
+{
+    private ?string $channelId = null;
+
+    private ?string $priority = null;
+
+    private ?int $ttl = null;
+
+    private ?string $collapseKey;
+
+    /** @var array<string,mixed> */
+    private array $notification = [];
+
+    /** @var array<string,mixed> */
+    private array $data = [];
+
+    /** @var array<string,mixed> */
+    private array $extra = [];
+
+    public static function make(): self
+    {
+        return new self();
+    }
+
+    public function withChannelId(string $channelId)
+    {
+        $this->channelId = $channelId;
+        $this->notification['channel_id'] = $channelId;
+        return $this;
+    }
+
+    public function withPriority(string $priority): self
+    {
+        $this->priority = $priority;
+        return $this;
+    }
+
+    public function withTtl(int $seconds): self
+    {
+        $this->ttl = $seconds;
+        return $this;
+    }
+
+    public function witlCollapseKey(string $key): self
+    {
+        $this->collapseKey = $key;
+        return $this;
+    }
+
+    /**
+     * @param array<string,mixed> $notification
+     */
+    public function withNotification(array $notification): self
+    {
+        $this->notification = array_replace_recursive($this->notification, $notification);
+        return $this;
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    public function withData(array $data): self
+    {
+        $this->data = $data;
+        return $this;
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     */
+    public function withExtra(array $extra): self
+    {
+        $this->extra = array_replace_recursive($this->extra, $extra);
+        return $this;
+    }
+
+    public function merge(self $other)
+    {
+        $merged = new self();
+
+        $merged->channelId = $other->channelId !== null ? $other->channelId : $this->channelId;
+        $merged->priority = $other->priority !== null ? $other->priority : $this->priority;
+        $merged->ttl = $other->ttl !== null ? $other->ttl : $this->ttl;
+        $merged->collapseKey = $other->collapseKey !== null ? $other->collapseKey : $this->collapseKey;
+        $merged->notification = array_replace_recursive($this->notification, $other->notification);
+        $merged->data = array_replace($this->data, $other->data);
+        $merged->extra = array_replace_recursive($this->extra, $other->extra);
+
+        return $merged;
+    }
+
+    public function toArray(): array
+    {
+        $output = [];
+
+        if ($this->priority !== null) {
+            $output['priority'] = $this->priority;
+        }
+
+        if ($this->ttl !== null) {
+            $output['ttl'] = $this->ttl;
+        }
+
+        if ($this->collapseKey !== null) {
+            $output['collapse_key'] = $this->collapseKey;
+        }
+
+        if (!empty($this->notification)) {
+            $output['notification'] = $this->notification;
+        }
+
+        if (!empty($this->data)) {
+            $output['data'] = $this->data;
+        }
+
+        if (!empty($this->extra)) {
+            $output = array_replace_recursive($output, $this->extra);
+        }
+
+        if ($this->channelId !== null) {
+            // Ensure channel_id is always set in notification for backward compatibility
+            if (!isset($output['notification'])) {
+                $output['notification'] = [];
+            }
+            $output['notification']['channel_id'] = $this->channelId;
+        }
+
+        return $output;
+    }
+}

--- a/src/Platform/ApnsOptions.php
+++ b/src/Platform/ApnsOptions.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Dev1\NotifyCore\Platform;
+
+use Dev1\NotifyCore\Contracts\PlatformOptions;
+
+final class ApnsOptions implements PlatformOptions
+{
+    /** @var array<string,mixed> */
+    private array $headers = [];
+
+    /** @var array<string,mixed> */
+    private array $aps = [];
+
+    /** @var array<string,mixed> */
+    private array $custom = [];
+
+    public static function make(): self
+    {
+        return new self();
+    }
+
+    /**
+     * @param array<string,string> $headers
+     */
+    public function withHeaders(array $headers): self
+    {
+        $this->headers = array_replace_recursive($this->headers, $headers);
+        return $this;
+    }
+
+    /**
+     * @param array<string,mixed> $aps
+     */
+    public function withAps(array $aps): self
+    {
+        $this->aps = array_replace_recursive($this->aps, $aps);
+        return $this;
+    }
+
+    /**
+     * @param array<string,mixed> $custom
+     */
+    public function withCustom(array $custom): self
+    {
+        $this->custom = array_replace_recursive($this->custom, $custom);
+        return $this;
+    }
+
+    public function merge(self $other)
+    {
+        $merged = new self();
+        $merged->headers = array_replace($this->headers, $other->headers);
+        $merged->aps = array_replace_recursive($this->aps, $other->aps);
+        $merged->custom = array_replace_recursive($this->custom, $other->custom);
+        return $merged;
+    }
+
+    public function toArray(): array
+    {
+        $payload = [];
+        if (!empty($this->headers)) {
+            $payload['headers'] = $this->headers;
+        }
+
+        $body = [];
+        if (!empty($this->aps)) {
+            $body['aps'] = $this->aps;
+        }
+        if (!empty($this->custom)) {
+            $body = array_merge($body, $this->custom);
+        }
+        if (!empty($body)) {
+            $payload['body'] = $body;
+        }
+
+        return $payload;
+    }
+}


### PR DESCRIPTION
### Added
- Support for custom notification channels in **Firebase Cloud Messaging**.
- New example in `examples/send_fcm_channels.php`.
- `AndroidOptions` and `ApnsOptions` to configure platform-specific options.
- `platformOverrides` in `PushMessage` to set platform-specific options.