### PR TITLE
Fixed bug at collapseKey

### DIFF
--- a/src/Platform/AndroidOptions.php
+++ b/src/Platform/AndroidOptions.php
@@ -12,7 +12,7 @@ final class AndroidOptions implements PlatformOptions
 
     private ?int $ttl = null;
 
-    private ?string $collapseKey;
+    private ?string $collapseKey = null;
 
     /** @var array<string,mixed> */
     private array $notification = [];


### PR DESCRIPTION
We have found a bug at implementing AndroidOptions which was making it unable to send emergency notifications.