### PR TITLE
Hotfix at deployment job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,9 @@ jobs:
       - name: Read library version
         id: version
         run: |
-          VERSION=$(php -r 'require "src/Version.php"; echo Dev1\\NotifyCore\\Version::VERSION;')
+          VERSION=$(php -r 'require "src/Version.php"; echo Dev1\NotifyCore\Version::VERSION;')
           if [ -z "$VERSION" ]; then
-            echo "::error::Unable to read Dev1\\NotifyCore\\Version::VERSION"
+            echo "::error::Unable to read Dev1\NotifyCore\Version::VERSION"
             exit 1
           fi
           echo "version=$VERSION"       >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow to fix the PHP namespace separator in the script that reads the library version.

* Corrected the PHP namespace separator from double backslashes (`\`) to a single backslash (`This pull request makes a minor update to the GitHub Actions workflow to fix the PHP namespace separator in the script that reads the library version.

) when referencing `Dev1\NotifyCore\Version::VERSION` in the workflow script in `.github/workflows/ci.yml`.